### PR TITLE
A couple of small changes to internal node labelling

### DIFF
--- a/src/java/tdg09/Analyse.java
+++ b/src/java/tdg09/Analyse.java
@@ -269,7 +269,15 @@ public class Analyse {
             System.out.printf("Alignment:\n  SequenceCount: %s\n  SiteCount: %s\n\n", alignment.getSequenceCount(), alignment.getSiteCount());
         }
 
-        // 2. Check that all taxa have an assigned group and all groups are used
+	// 2. Check that group names have the right length
+	for (String group : options.groups) {
+	    if (group.length() > 2) {
+		System.out.println("ERROR: Group names must be at most two characters long.");
+		System.exit(1);
+	    }
+	}
+
+        // 3. Check that all taxa have an assigned group and all groups are used
         List<String> taxa = Lists.newArrayList();
         Set<String> usedGroups = Sets.newHashSet();
 

--- a/src/java/tdg09/trees/TreeNodeLabeller.java
+++ b/src/java/tdg09/trees/TreeNodeLabeller.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Collections;
 
 /**
  * Takes a tree where taxa have been prefixed by a two-letter partition/group identifier and traverses the tree to
@@ -90,6 +91,10 @@ public class TreeNodeLabeller {
         }
 
         // now the only remaining unknown nodes are those that neighbour two different clades (and the root node)
+
+	// Iterate over unknownNodes in reverse to make sure the parent nodes are labelled before child nodes
+	Collections.reverse(unknownNodes);
+
         for (Node n : unknownNodes) {
             // the name of this hostshift node = parent node name (remember, could be the root node = leave unlabelled)
             if (n.getParent() != null) {


### PR DESCRIPTION
Hi Asif,
I had a go at fixing two small issues with labelling internal nodes I've encountered while running ``tdg09`` on two fairly messy trees with a lot of group switches. I first noticed that tree labelling was crashing if the name of a group was longer than two characters and added a simple check for this.

This helped with one tree but labelling still crashed on the other. I think the issue was caused by parent-child node pairs that were both group switch ("_GS") nodes. In such cases, children nodes are labelled first but this was failing as the labels are set based on the group of the parent (which is at that point unlabelled). I think simply iterating over ``unknownNodes`` in reverse ensures the right order but I haven't tested this change extensively.